### PR TITLE
[WIP]Count number of good locations before showing Start button.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="resolveModulePerSourceSet" value="false" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/build/classes" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="Android" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/AndroidLocationStarterKit.iml" filepath="$PROJECT_DIR$/.idea/modules/AndroidLocationStarterKit.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/goldrushcomputing/androidlocationstarterkit/MainActivity.java
+++ b/app/src/main/java/com/goldrushcomputing/androidlocationstarterkit/MainActivity.java
@@ -77,6 +77,10 @@ public class MainActivity extends AppCompatActivity {
     ArrayList<Marker> malMarkers = new ArrayList<>();
     final Handler handler = new Handler();
 
+    /* Check enough good locations before showing START button */
+    private BroadcastReceiver enoughLocationsReceiver;
+    private boolean showStartButton = false;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -136,6 +140,13 @@ public class MainActivity extends AppCompatActivity {
         });
 
 
+        enoughLocationsReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                // Make startButton visible
+                startButton.setVisibility(View.VISIBLE);
+            }
+        };
 
 
         locationUpdateReceiver = new BroadcastReceiver() {
@@ -168,6 +179,9 @@ public class MainActivity extends AppCompatActivity {
         };
 
 
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+            enoughLocationsReceiver,
+            new IntentFilter("GotEnoughLocations"));
 
         LocalBroadcastManager.getInstance(this).registerReceiver(
                 locationUpdateReceiver,
@@ -181,6 +195,7 @@ public class MainActivity extends AppCompatActivity {
 
         startButton = (ImageButton) this.findViewById(R.id.start_button);
         stopButton = (ImageButton) this.findViewById(R.id.stop_button);
+        startButton.setVisibility(View.INVISIBLE);
         stopButton.setVisibility(View.INVISIBLE);
 
 


### PR DESCRIPTION
This is a demo to show how we can count good locations before allowing user to track their locations.
Here is the step
## 1. 
Add a varibale `goodGpsCount` to count the number of initial good locations.
[goodGpsCount](https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-73ccae8d1b2c89ef24ff25f60549f85125dc67d46c73e466ed9e0c19e2109129R66)

## 2. 
In onLocationUpdate, after filtering the new location, if it passes the filter, count up `goodGpsCount`. 
If `goodGpsCount` becomes more than or equal to 3, send broadcast to MainActivity.
https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-73ccae8d1b2c89ef24ff25f60549f85125dc67d46c73e466ed9e0c19e2109129R66


## 3.
In MainActivity, make the `startButton` invisible in the beginning.
https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-e4363ca693431b2287ffc5ce969d0abac1ee05f8729ff2d3a4efda2db4ca9df3R174

## 4. 
When receiving the broadcast of goodGpsCount, make `startButton` visible.
https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-e4363ca693431b2287ffc5ce969d0abac1ee05f8729ff2d3a4efda2db4ca9df3R144
 
 
# Other Note
* I changed the function `filterAndAddLocation` to `filterLocation` to return null (if location doesn't pass the filter) or location (if the location passes the filter). This is because I want to use this function even before the user presses `startButton`. 
* I removed Kalman filter to demonstrate this idea with maximum simplicity.