### PR TITLE
Count number of good locations before showing Start button. 

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_28.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-05-05T00:44:26.799631Z" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.goldrushcomputing.androidlocationstarterkit"

--- a/app/src/main/java/com/goldrushcomputing/androidlocationstarterkit/LocationService.java
+++ b/app/src/main/java/com/goldrushcomputing/androidlocationstarterkit/LocationService.java
@@ -56,6 +56,7 @@ public class LocationService extends Service implements LocationListener, GpsSta
     int batteryScale;
     int gpsCount;
 
+    int goodGpsCount;
 
     public LocationService() {
 
@@ -244,6 +245,8 @@ public class LocationService extends Service implements LocationListener, GpsSta
                 batteryLevelArray.clear();
                 batteryLevelScaledArray.clear();
 
+                goodGpsCount = 0;
+
             } catch (IllegalArgumentException e) {
                 Log.e(LOG_TAG, e.getLocalizedMessage());
             } catch (SecurityException e) {
@@ -269,9 +272,23 @@ public class LocationService extends Service implements LocationListener, GpsSta
 
         gpsCount++;
 
+        Location filtered = filterLocation(newLocation);
+
         if(isLogging){
-            //locationList.add(newLocation);
-            filterAndAddLocation(newLocation);
+            if(filtered != null){
+                currentSpeed = filtered.getSpeed();
+                locationList.add(filtered);
+            }
+        }else{
+            // if newLocation passed the filter, count up goodLocationCount.
+            if(filtered != null){
+                goodGpsCount++;
+                if(goodGpsCount > 2){
+                    Intent intent = new Intent("GotEnoughLocations");
+                    intent.putExtra("goodLocationCount", goodGpsCount);
+                    LocalBroadcastManager.getInstance(this.getApplication()).sendBroadcast(intent);
+                }
+            }
         }
 
         Intent intent = new Intent("LocationUpdated");
@@ -294,20 +311,20 @@ public class LocationService extends Service implements LocationListener, GpsSta
     }
 
 
-    private boolean filterAndAddLocation(Location location){
+    private Location filterLocation(Location location){
 
         long age = getLocationAge(location);
 
         if(age > 5 * 1000){ //more than 5 seconds
             Log.d(TAG, "Location is old");
             oldLocationList.add(location);
-            return false;
+            return null;
         }
 
         if(location.getAccuracy() <= 0){
             Log.d(TAG, "Latitidue and longitude values are invalid.");
             noAccuracyLocationList.add(location);
-            return false;
+            return null;
         }
 
         //setAccuracy(newLocation.getAccuracy());
@@ -315,56 +332,11 @@ public class LocationService extends Service implements LocationListener, GpsSta
         if(horizontalAccuracy > 10){ //10meter filter
             Log.d(TAG, "Accuracy is too low.");
             inaccurateLocationList.add(location);
-            return false;
+            return null;
         }
-
-
-        /* Kalman Filter */
-        float Qvalue;
-
-        long locationTimeInMillis = (long)(location.getElapsedRealtimeNanos() / 1000000);
-        long elapsedTimeInMillis = locationTimeInMillis - runStartTimeInMillis;
-
-        if(currentSpeed == 0.0f){
-            Qvalue = 3.0f; //3 meters per second
-        }else{
-            Qvalue = currentSpeed; // meters per second
-        }
-
-        kalmanFilter.Process(location.getLatitude(), location.getLongitude(), location.getAccuracy(), elapsedTimeInMillis, Qvalue);
-        double predictedLat = kalmanFilter.get_lat();
-        double predictedLng = kalmanFilter.get_lng();
-
-        Location predictedLocation = new Location("");//provider name is unecessary
-        predictedLocation.setLatitude(predictedLat);//your coords of course
-        predictedLocation.setLongitude(predictedLng);
-        float predictedDeltaInMeters =  predictedLocation.distanceTo(location);
-
-        if(predictedDeltaInMeters > 60){
-            Log.d(TAG, "Kalman Filter detects mal GPS, we should probably remove this from track");
-            kalmanFilter.consecutiveRejectCount += 1;
-
-            if(kalmanFilter.consecutiveRejectCount > 3){
-                kalmanFilter = new KalmanLatLong(3); //reset Kalman Filter if it rejects more than 3 times in raw.
-            }
-
-            kalmanNGLocationList.add(location);
-            return false;
-        }else{
-            kalmanFilter.consecutiveRejectCount = 0;
-        }
-
-        /* Notifiy predicted location to UI */
-        Intent intent = new Intent("PredictLocation");
-        intent.putExtra("location", predictedLocation);
-        LocalBroadcastManager.getInstance(this.getApplication()).sendBroadcast(intent);
 
         Log.d(TAG, "Location quality is good enough.");
-        currentSpeed = location.getSpeed();
-        locationList.add(location);
-
-
-        return true;
+        return location;
     }
 
 

--- a/app/src/main/java/com/goldrushcomputing/androidlocationstarterkit/MainActivity.java
+++ b/app/src/main/java/com/goldrushcomputing/androidlocationstarterkit/MainActivity.java
@@ -77,6 +77,10 @@ public class MainActivity extends AppCompatActivity {
     ArrayList<Marker> malMarkers = new ArrayList<>();
     final Handler handler = new Handler();
 
+    /* Check enough good locations before showing START button */
+    private BroadcastReceiver enoughLocationsReceiver;
+    private boolean showStartButton = false;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -136,6 +140,13 @@ public class MainActivity extends AppCompatActivity {
         });
 
 
+        enoughLocationsReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                // Make startButton visible
+                startButton.setVisibility(View.VISIBLE);
+            }
+        };
 
 
         locationUpdateReceiver = new BroadcastReceiver() {
@@ -168,6 +179,9 @@ public class MainActivity extends AppCompatActivity {
         };
 
 
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+            enoughLocationsReceiver,
+            new IntentFilter("GotEnoughLocations"));
 
         LocalBroadcastManager.getInstance(this).registerReceiver(
                 locationUpdateReceiver,
@@ -181,6 +195,7 @@ public class MainActivity extends AppCompatActivity {
 
         startButton = (ImageButton) this.findViewById(R.id.start_button);
         stopButton = (ImageButton) this.findViewById(R.id.stop_button);
+        startButton.setVisibility(View.INVISIBLE);
         stopButton.setVisibility(View.INVISIBLE);
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:7.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
This is a demo to show how we can count good locations before allowing user to track their locations.
Here is the step
## 1. 
Add a varibale `goodGpsCount` to count the number of initial good locations.
https://github.com/mizutori/AndroidLocationStarterKit/pull/6/files#diff-93d98e0953cbfe5d527fa9991537cb545dd5dbe6d4b4dfc65992105478fc2077R59

## 2. 
In onLocationUpdate, after filtering the new location, if it passes the filter, count up `goodGpsCount`. 
If `goodGpsCount` becomes more than or equal to 3, send broadcast to MainActivity.
https://github.com/mizutori/AndroidLocationStarterKit/pull/6/files#diff-93d98e0953cbfe5d527fa9991537cb545dd5dbe6d4b4dfc65992105478fc2077R286


## 3.
In MainActivity, make the `startButton` invisible in the beginning.
https://github.com/mizutori/AndroidLocationStarterKit/pull/6/files#diff-40c5403e3f39c3d55b4e8d6447d31e6378231d346d6d955214bcc10bc9c3aa31R198

## 4. 
When receiving the broadcast of goodGpsCount, make `startButton` visible.
https://github.com/mizutori/AndroidLocationStarterKit/pull/6/files#diff-40c5403e3f39c3d55b4e8d6447d31e6378231d346d6d955214bcc10bc9c3aa31R147
 
 
# Other Note
* I changed the function `filterAndAddLocation` to `filterLocation` to return null (if location doesn't pass the filter) or location (if the location passes the filter). This is because I want to use this function even before the user presses `startButton`. 
* I removed Kalman filter to demonstrate this idea with maximum simplicity.